### PR TITLE
Fix build on Ubuntu 18.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(simple-spectral)
 
@@ -20,6 +20,9 @@ find_package(GLM REQUIRED)
 message(STATUS "GLM at ${GLM_INCLUDE_DIR}")
 include_directories(${GLM_INCLUDE_DIRS})
 set(EXTERNAL_LIBRARIES ${EXTERNAL_LIBRARIES} ${GLM_LIBRARIES})
+if (UNIX)
+	set(EXTERNAL_LIBRARIES ${EXTERNAL_LIBRARIES} pthread)
+endif()
 
 if(SUPPORT_WINDOWED)
 	add_definitions("-DSUPPORT_WINDOWED")

--- a/src/util/random.cpp
+++ b/src/util/random.cpp
@@ -130,12 +130,12 @@ Dir rand_toward_sphericaltri(RNG& rng, SphericalTriangle const& tri) {
 		return dir * glm::inversesqrt(lensq);
 	};
 
-	glm::vec3 C_hat = q*tri.A + sqrt(1-q*q)*func_bar(tri.C,tri.A);
+	glm::vec3 C_hat = q*tri.A + sqrtf(1-q*q)*func_bar(tri.C,tri.A);
 
 	float z = 1.0f - r1*( 1.0f - glm::dot(C_hat,tri.B) );
 	z = glm::clamp( z, -1.0f,1.0f ); //Numerical issues
 
-	Dir result = z*tri.B + sqrt(1-z*z)*func_bar(C_hat,tri.B);
+	Dir result = z*tri.B + sqrtf(1-z*z)*func_bar(C_hat,tri.B);
 	assert(!std::isnan(result.x)&&!std::isnan(result.y)&&!std::isnan(result.z));
 	return result;
 }

--- a/src/util/spherical-tri.hpp
+++ b/src/util/spherical-tri.hpp
@@ -11,14 +11,9 @@ namespace Math {
 class SphericalTriangle final {
 	public:
 		//Vertices
-		union {
-			struct {
-				Pos A;
-				Pos B;
-				Pos C;
-			};
-			Pos ABC[3];
-		};
+		Pos A;
+		Pos B;
+		Pos C;
 
 		float a,b,c; //Side lengths (on the surface of the sphere); also equal to the angle they subtend.
 		float sin_a,sin_b,sin_c; //Sine of angles subtended by sides.


### PR DESCRIPTION
These changes get the code building for me on stock Ubuntu 18.04 using gcc 7.4. The most invasive part is changing the `SphericalTriangle` class to contain the A, B and C `Pos` structs directly rather than in an anonymous union, which is allowed on MSVC and Clang but not GCC. Since the ABC variant of the union doesn't appear to be used anywhere this looks fine to me.